### PR TITLE
set client id from env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,43 @@ group chats, and meeting chats.
 
 ## Design Goals
 
-Unlike similar export tools, this does NOT require using Windows or PowerShell, or registering
-an application with the Microsoft Identity Platform. The only requirement is Python.
+Unlike similar export tools, this does NOT require using Windows or PowerShell. The only requirement is Python.
+
+Originally you did not need to register an application with the Microsoft Identity Platform or Microsoft Entra ID,
+but as of Sept 9th, 2024, [that is no longer the case](https://pnp.github.io/blog/post/changes-pnp-management-shell-registration/).
 
 This was created specifically in response to a new retention policy for Teams chats
 implemented at my workplace.
 
 ## Instructions
+
+
+### Create an Entra ID application if needed
+
+You'll need either an existing Entra ID application with permissions to access Teams,
+or you'll need to create a new one.
+
+If you have an existing application, find its application/client ID.
+
+If you need to create one, the steps are [here](https://pnp.github.io/powershell/articles/registerapplication.html#manually-create-an-app-registration-for-interactive-login).
+In a nutshell:
+
+- Log into https://entra.microsoft.com/
+- Navigate to Applications -> App Registrations
+- Click "New registration" and give it a name like "Teams API"
+- Navigate to Authentication for the new app
+- Click "Add a platform" and select "Mobile and desktop applications"
+- Enter the following custom redirect URI: http://localhost:8400
+- Save your changes
+
+You don't need to configure specific API permissions. The default "User.Read" delegated
+permission will give users access to their own Teams data.
+
+Copy your new application's "Application (client) ID" from the Overview screen. It should look
+something like "31359c7f-bd7e-475c-86db-fdb8c937548e" (that's the ID for the old built-in
+PnP Management Shell Entra App that Microsoft has disabled, it won't work).
+
+### Run the script
 
 To archive your chats:
 
@@ -27,7 +57,12 @@ pip install -r requirements.txt
 
 # run two steps to download and generate html files in the './archive' directory
 # to use another dir, set --output-dir=/some/other/dir
-python teams_chats_export.py download
+
+# step one: download
+# replace value for CLIENT_ID with your own ID
+CLIENT_ID="31359c7f-bd7e-475c-86db-fdb8c937548e" python teams_chats_export.py download
+
+# step two: generate html files
 python teams_chats_export.py generate_html
 ```
 

--- a/teams_chats_export.py
+++ b/teams_chats_export.py
@@ -8,6 +8,7 @@ import os
 import pprint
 import re
 import shutil
+import sys
 from typing import Dict, Optional
 
 from azure.identity import InteractiveBrowserCredential
@@ -20,11 +21,7 @@ from msgraph.generated.chats.chats_request_builder import ChatsRequestBuilder
 from msgraph.generated.chats.item.messages.messages_request_builder import MessagesRequestBuilder
 import pytz
 
-# this is the universal client id (aka application id) used by Microsoft's "PnP PowerShell".
-# users typically are granted access to this in every organization and lets us avoid having
-# to create an Azure Application and grant it permissions for use with the MS Graph API.
-# see https://pnp.github.io/powershell/cmdlets/Request-PnPAccessToken.html
-pnp_management_shell_client_id = "31359c7f-bd7e-475c-86db-fdb8c937548e"
+client_id = os.getenv("CLIENT_ID")
 
 filename_size_limit = 255
 
@@ -369,7 +366,11 @@ def render_all(output_dir):
 
 
 def get_graph_client() -> GraphServiceClient:
-    credential = InteractiveBrowserCredential(client_id=pnp_management_shell_client_id)
+    if not client_id:
+        print("Error: the CLIENT_ID environment variable isn't set")
+        sys.exit(1)
+
+    credential = InteractiveBrowserCredential(client_id=client_id)
     scopes = ["Chat.Read"]
     client = GraphServiceClient(credentials=credential, scopes=scopes)
     return client


### PR DESCRIPTION
Resolves #2 

Nothing is replacing the built-in PnP Management Shell Entra App, so users will need to create their own Entra ID app. I've updated the README with instructions on how to do that, and provided a way to set the application/client ID via an environment variable.

